### PR TITLE
Schema400 bug

### DIFF
--- a/components/perspective.js
+++ b/components/perspective.js
@@ -327,16 +327,14 @@ Perspective.prototype.create = function(perspective, cb) {
 Perspective.prototype.update = function(perspective, cb) {
   if (perspective.hasOwnProperty('schema')) {
     perspective = perspective.schema;
-    // filters out constant type 'Version' which is no longer acceptable
-    var constants = perspective.constants;
-    perspective.constants = constants.filter((constant) => {
-      return constant.type !== 'Version';
-    })
   }
+  // filters out constant type 'Version' which is no longer acceptable
+  var constants = perspective.constants;
+  perspective.constants = constants.filter((constant) => {
+    return constant.type !== 'Version';
+  })
 
   var options = this._options('PUT', '/' + perspective.id);
-
-
 
   utils.send_request(options, JSON.stringify({schema: perspective}), cb);
 };

--- a/components/perspective.js
+++ b/components/perspective.js
@@ -87,6 +87,7 @@ Perspective.prototype._get_cb = function(flags, id, cb, err, result) {
   if (err) return cb(err, result);
 
   result = result.schema;
+
   result.id = id;
   return cb(null, result);
 };
@@ -326,9 +327,16 @@ Perspective.prototype.create = function(perspective, cb) {
 Perspective.prototype.update = function(perspective, cb) {
   if (perspective.hasOwnProperty('schema')) {
     perspective = perspective.schema;
+    // filters out constant type 'Version' which is no longer acceptable
+    var constants = perspective.constants;
+    perspective.constants = constants.filter((constant) => {
+      return constant.type !== 'Version';
+    })
   }
 
   var options = this._options('PUT', '/' + perspective.id);
+
+
 
   utils.send_request(options, JSON.stringify({schema: perspective}), cb);
 };

--- a/test/unit/components/perspective.unit.js
+++ b/test/unit/components/perspective.unit.js
@@ -12,7 +12,7 @@ var Perspective = proxyquire('../../../components/perspective', {
 });
 var EventEmitter = require('events');
 
-describe.only('Perspective', function() {
+describe('Perspective', function() {
   var p;
 
   describe('constructor', function() {
@@ -1265,7 +1265,7 @@ describe.only('Perspective', function() {
         done();
       });
 
-      p.update({id: 1}, function(err, json) {});
+      p.update({id: 1, constants: [{type: 'test'}]}, function(err, json) {});
 
       request.restore();
     });
@@ -1278,7 +1278,7 @@ describe.only('Perspective', function() {
         done();
       });
 
-      special_p.update({id: 1}, function(err, json) {});
+      special_p.update({id: 1, constants: [{type: 'test'}]}, function(err, json) {});
 
       request.restore();
     });
@@ -1289,7 +1289,7 @@ describe.only('Perspective', function() {
         done();
       });
 
-      p.update({id: 1}, function(err, json) {});
+      p.update({id: 1, constants: [{type: 'test'}]}, function(err, json) {});
 
       request.restore();
     });
@@ -1302,7 +1302,7 @@ describe.only('Perspective', function() {
         done();
       });
 
-      p.update({id: id}, function(err, json) {});
+      p.update({id: id, constants: [{type: 'test'}]}, function(err, json) {});
 
       request.restore();
     });
@@ -1327,7 +1327,7 @@ describe.only('Perspective', function() {
         cb(error);
       });
 
-      p.update({id: 1}, function(err, json) {
+      p.update({id: 1, constants: [{type: 'test'}]}, function(err, json) {
         expect(err).to.equal(error);
         done();
       });
@@ -1336,7 +1336,7 @@ describe.only('Perspective', function() {
     });
 
     it('should wrap the new perspective in a object under the "schema" field', function(done) {
-      var obj = {test: 'test'};
+      var obj = {test: 'test', constants: [{type: 'test'}]};
 
       var request = sinon.stub(utils, 'send_request', function(options, send_data, cb) {
         expect(JSON.parse(send_data).schema).to.eql(obj);
@@ -1370,7 +1370,7 @@ describe.only('Perspective', function() {
         cb(null, test_json);
       });
 
-      p.update({id: 1}, function(err, json) {
+      p.update({id: 1, constants: [{type: 'test'}]}, function(err, json) {
         expect(json).to.equal(test_json);
         done();
       });

--- a/test/unit/components/perspective.unit.js
+++ b/test/unit/components/perspective.unit.js
@@ -12,7 +12,7 @@ var Perspective = proxyquire('../../../components/perspective', {
 });
 var EventEmitter = require('events');
 
-describe('Perspective', function() {
+describe.only('Perspective', function() {
   var p;
 
   describe('constructor', function() {
@@ -1307,6 +1307,19 @@ describe('Perspective', function() {
       request.restore();
     });
 
+    it('should parse out the constant type "Version" from all schemas', function() {
+      var obj = {schema: {constants: [{type: 'Version'},{type: 'Static Group'}]}};
+      var parsedObj = {schema: {constants: [{type: 'Static Group'}]}};
+
+      var request = sinon.stub(utils, 'send_request')
+
+      p.update(obj, function(err, json) {});
+      expect(request.args[0][1]).to.equal(JSON.stringify(parsedObj));
+
+      request.restore();
+
+    });
+
     it('should call the callback with an error if #_send_request fails', function(done) {
       var error = new Error('test');
 
@@ -1336,7 +1349,7 @@ describe('Perspective', function() {
     });
 
     it('should not wrap the new perspective in "schema" again if it contains the schema field already', function(done) {
-      var obj = {schema: {test: 'test'}};
+      var obj = {schema: {constants: [{type: 'test'}]}};
 
       var request = sinon.stub(utils, 'send_request', function(options, send_data, cb) {
         expect(JSON.parse(send_data)).to.eql(obj);


### PR DESCRIPTION
Can be tested with npm test, I added a test that shows that the code will parse out the constant type "Version" from a perspective object that is passed to the perspective.prototype.update function.  I also updated the remaining tests for the update function, namely adding in constant:type to the test object passed to the function.

I just tested on the markAccountDeleted script by pasting the code into the cox-chapi node module, as it is an npm module we will need to publish an update to npm in order to use it properly. I can show you a screen shot if you want showing how it correctly parses out the constant type.