### PR TITLE
Update schema fix

### DIFF
--- a/components/account.js
+++ b/components/account.js
@@ -113,7 +113,7 @@ Account.prototype._list_cb = function(flags, cb, err, result) {
  *  @param {arrayCallback} cb - called with an array of accounts
  */
 Account.prototype._list_all = function(cb) {
-  this.list({stats: true}, (err, stats) => {
+  this.list({stats: true, page_count: 200}, (err, stats) => {
     if (err) return cb(err);
     var calls = [];
     for (var i=0, len=stats.page_count; i<len; i++) {
@@ -171,7 +171,7 @@ Account.prototype._find_by = function(field, value, list, cb) {
     cb(null, matches);
   }
   else {
-    this.list({all: true}, (err, matches) => {
+    this.list({all: true, page_count: 200}, (err, matches) => {
       if (err) return cb(err);
       this.find_by(field, value, matches, cb);
     });

--- a/components/perspective.js
+++ b/components/perspective.js
@@ -251,6 +251,22 @@ Perspective.prototype._get_rule = function(pers, group_id) {
 };
 
 /**
+ * remove previous references to an account within the rules of the schema
+ * @function module:cox-chapi.Perspective#remove_prev_refs
+ * @param {object} pers - a perspective containing rules
+ * @param  {string} account_ref_id ref_id of the account
+ * @returns {Object}               returns updated perspective schema
+ */
+Perspective.prototype.remove_prev_refs = function(pers, account_ref_id) {
+  pers.rules = pers.rules.map((rule) => {
+    if (rules.asset === 'AwsAccount'){
+      rule.condition.clauses = rule.condition.clauses.filter(clause => clause.asset_ref !== account_ref_id);
+    };
+  });
+  return pers;
+}
+
+/**
  *  gets a JSON object containing all the perspectives
  *  @function module:cox-chapi.Perspective#list
  *  @param {object} [flags] - an optional flags object

--- a/components/perspective.js
+++ b/components/perspective.js
@@ -6,7 +6,6 @@
 
 var https = require('https');
 var utils = require('../utils/chapi.js');
-var fs = require('fs');
 
 /**
  *  @class Perspective
@@ -223,7 +222,7 @@ Perspective.prototype.add_to_group = function(pers, accts, group_name, cb) {
  *  @function module:cox-chapi.Perspective#_get_rule
  *  @private
  *  @param {object} pers - a perspective containing rules
- *  @param {string} to_group_id - the id of the group that the rule points to
+ *  @param {string} group_id - the id of the group that the rule points to
  *  @return {object} the matching rule, or a new rule that has already been
  *                   added to the perspective
  */

--- a/components/perspective.js
+++ b/components/perspective.js
@@ -227,20 +227,20 @@ Perspective.prototype.add_to_group = function(pers, accts, group_name, cb) {
  *  @return {object} the matching rule, or a new rule that has already been
  *                   added to the perspective
  */
-Perspective.prototype._get_rule = function(pers, to_group_id) {
+Perspective.prototype._get_rule = function(pers, group_id) {
   // get the rule specifying accounts that belong to this group
   var rule;
 
   if (pers.rules.length) {
     rule = pers.rules.find(
-      (rule) => rule.asset === 'AwsAccount' && rule.to === to_group_id && rule.from === undefined
+      (rule) => rule.asset === 'AwsAccount' && rule.to === group_id && rule.from === undefined
     );
   }
   // if the rule doesn't exist, make a rule
   if (!rule) {
     rule = {
       asset: 'AwsAccount',
-      to: to_group_id,
+      to: group_id,
       type: 'filter',
       condition: {
         clauses: [],
@@ -265,7 +265,6 @@ Perspective.prototype.remove_prev_refs = function(pers, account_ref_id) {
     };
   });
   pers.rules = pers.rules.filter(rule => rule.condition.clauses.length);
-  console.log(pers);
   return pers;
 }
 

--- a/components/perspective.js
+++ b/components/perspective.js
@@ -253,18 +253,20 @@ Perspective.prototype._get_rule = function(pers, group_id) {
 /**
  * remove previous references to an account within the rules of the schema
  * @function module:cox-chapi.Perspective#remove_prev_refs
- * @param {object} pers - a perspective containing rules
- * @param  {string} account_ref_id ref_id of the account
- * @returns {Object}               returns updated perspective schema
+ * @param {object} options options object of params
+ * @param {object} options.pers - a perspective containing rules
+ * @param  {string} options.account_ref_id ref_id of the account
+ * @param  {objectCallback} cb - called with the updated pers object
+
  */
-Perspective.prototype.remove_prev_refs = function(pers, account_ref_id) {
+Perspective.prototype.remove_prev_refs = function({ pers, account_ref_id }, cb) {
   pers.rules.forEach((rule) => {
     if (rule.asset === 'AwsAccount'){
       rule.condition.clauses = rule.condition.clauses.filter(clause => clause.asset_ref != account_ref_id);
     };
   });
   pers.rules = pers.rules.filter(rule => rule.condition.clauses.length);
-  return pers;
+  cb(null, pers);
 }
 
 /**

--- a/components/perspective.js
+++ b/components/perspective.js
@@ -50,21 +50,25 @@ Perspective.prototype._options = function(method, path, params) {
  */
 Perspective.prototype.get = function(flags, id, cb) {
   if (typeof id === 'function') {
+    console.log('inside if checking id type');
     cb = id;
     id = flags;
     flags = null;
   }
   // ensure id is a string
   id = '' + id;
-
+  console.log(flags);
+  console.log(id);
   // if "id" is a name, lookup the name
   if (!id.match(/^[0-9]+$/)) {
+    console.log('inside if of get')
     this._lookup_id(flags, id, (err, id) => {
       if (err) return cb(err, id);
       this.get(id, cb);
     });
   }
   else {
+    console.log('before _get in get in perspective definition');
     return this._get(flags, id, cb);
   }
 }
@@ -75,7 +79,7 @@ Perspective.prototype.get = function(flags, id, cb) {
  */
 Perspective.prototype._get = function(flags, id, cb) {
   var options = this._options('GET', '/' + id, ['include_version=true']);
-
+  console.log('after options in _get');
   utils.send_request(options, null, this._get_cb.bind(this, flags, id, cb));
 };
 
@@ -230,10 +234,13 @@ Perspective.prototype.add_to_group = function(pers, accts, group_name, cb) {
  */
 Perspective.prototype._get_rule = function(pers, group_id) {
   // get the rule specifying accounts that belong to this group
-  var rule = pers.rules.find(
-    (rule) => rule.asset === 'AwsAccount' && rule.to === group_id
-  );
-
+  var rule;
+  console.log(pers);
+  if (pers.rules.length) {
+    rule = pers.rules.find(
+      (rule) => rule.asset === 'AwsAccount' && rule.to === group_id
+    );
+  }
   // if the rule doesn't exist, make a rule
   if (!rule) {
     rule = {
@@ -258,11 +265,18 @@ Perspective.prototype._get_rule = function(pers, group_id) {
  * @returns {Object}               returns updated perspective schema
  */
 Perspective.prototype.remove_prev_refs = function(pers, account_ref_id) {
-  pers.rules = pers.rules.map((rule) => {
-    if (rules.asset === 'AwsAccount'){
-      rule.condition.clauses = rule.condition.clauses.filter(clause => clause.asset_ref !== account_ref_id);
+  console.log(`account ref id: ${account_ref_id}`);
+  pers.rules.forEach((rule) => {
+    if (rule.asset === 'AwsAccount'){
+      rule.condition.clauses = rule.condition.clauses.filter(clause => {
+        console.log(`clause asset ref: ${clause.asset_ref}`);
+        return clause.asset_ref != account_ref_id;
+      });
     };
   });
+  pers.rules = pers.rules.filter(rule => rule.condition.clauses.length);
+  pers.rules.forEach(rule => console.log(`conditions: ${rule.condition.clauses}`));
+  console.log(pers);
   return pers;
 }
 

--- a/test/unit/components/perspective.unit.js
+++ b/test/unit/components/perspective.unit.js
@@ -904,9 +904,9 @@ describe('Perspective', function() {
     });
   });
 
-  describe('#remove_prev_refs', () => {
+  describe.only('#remove_prev_refs', () => {
     const account_ref_id = '1234';
-    const persInput = {
+    const pers = {
       rules: [
         {
           asset: 'AwsAccount',
@@ -957,9 +957,11 @@ describe('Perspective', function() {
       p = new Perspective();
     });
 
-    it('should remove any clauses that contain refs to the account and then remove empty rules', () => {
-      const result = p.remove_prev_refs(persInput, account_ref_id);
-      expect(result).to.be.eql(persOutput);
+    it('should remove any clauses that contain refs to the account and then remove empty rules', (done) => {
+      p.remove_prev_refs({ pers, account_ref_id }, (err, data) => {
+        expect(data).to.be.eql(persOutput);
+        done();
+      });
     });
   })
 

--- a/test/unit/components/perspective.unit.js
+++ b/test/unit/components/perspective.unit.js
@@ -12,7 +12,7 @@ var Perspective = proxyquire('../../../components/perspective', {
 });
 var EventEmitter = require('events');
 
-describe.only('Perspective', function() {
+describe('Perspective', function() {
   var p;
 
   describe('constructor', function() {

--- a/test/unit/components/perspective.unit.js
+++ b/test/unit/components/perspective.unit.js
@@ -904,7 +904,7 @@ describe('Perspective', function() {
     });
   });
 
-  describe.only('#remove_prev_refs', () => {
+  describe('#remove_prev_refs', () => {
     const account_ref_id = '1234';
     const pers = {
       rules: [

--- a/utils/chapi.js
+++ b/utils/chapi.js
@@ -410,7 +410,6 @@ function send_request(flags, options, send_data, cb) {
       }
 
       if((res.statusCode < 200) || (res.statusCode >= 300)) {
-        console.log(json);
         cb(new Error('Request received status code: ' + res.statusCode + '\n'), json);
       }
       else {
@@ -459,7 +458,6 @@ function set_cache(cache_name, cache, cb) {
       if (cb) return cb(err1);
       else throw err1;
     }
-    console.log('inside set_cache');
     settings.cache[cache_name] = cache;
 
     this._set_settings(settings, (err2, settings) => {

--- a/utils/chapi.js
+++ b/utils/chapi.js
@@ -458,7 +458,7 @@ function set_cache(cache_name, cache, cb) {
       if (cb) return cb(err1);
       else throw err1;
     }
-
+    console.log('inside set_cache');
     settings.cache[cache_name] = cache;
 
     this._set_settings(settings, (err2, settings) => {

--- a/utils/chapi.js
+++ b/utils/chapi.js
@@ -410,6 +410,7 @@ function send_request(flags, options, send_data, cb) {
       }
 
       if((res.statusCode < 200) || (res.statusCode >= 300)) {
+        console.log(json);
         cb(new Error('Request received status code: ' + res.statusCode + '\n'), json);
       }
       else {


### PR DESCRIPTION
Pretty straightforward.  Adds function remove_pref_refs to Perspective prototype for removing references within the perspective schema to the account that is being moved.  Adds additional filter to _get_rule to not return rules that have a defined "from" key. Updates tests for _get_rule to test that.

npm test should show full coverage.

Let me know if you have any questions.